### PR TITLE
fixed playground file typo

### DIFF
--- a/MyPlayground.playground/Pages/main.xcplaygroundpage/Contents.swift
+++ b/MyPlayground.playground/Pages/main.xcplaygroundpage/Contents.swift
@@ -8,13 +8,14 @@
  * [Switch Statements]https://github.com/learn-co-curriculum/swift-switchStatement-readme)
  * [Booleans and Operators](https://github.com/learn-co-curriculum/swift-booleans-readme)
  * [Conditionals](https://github.com/learn-co-curriculum/swift-conditionals-readme)
- 
+ */
 
 
 /*: Question 1
 ### 1. Add two Doubles
 */
 // write your code here
+ 
 
 
 /*: Question 2
@@ -94,4 +95,4 @@
 */
 // write your code here
 
-*/
+


### PR DESCRIPTION
Tried to write code for lab but nothing was highlighting or compiling. I unchecked "render documentation" and the whole lab was commented out from top to bottom. I uncommented the body of the lab so that answers could be coded and compiled.